### PR TITLE
Adjusted VimShiftTabPress for smoother operation

### DIFF
--- a/Vimdentation.py
+++ b/Vimdentation.py
@@ -37,8 +37,12 @@ class VimTabPressCommand(sublime_plugin.TextCommand):
                     i += space_count
             else:
                 # For those cases where nothing is selected, put the
-                # spaces whereever the cursor is.
-                self.view.insert(edit, region.begin(), spaces)
+                # spaces whereever the cursor is.  Handle tab stops by
+                # calculating our current position within the line
+                line = self.view.line(region)
+                spaces_to_insert = space_count - ((region.begin() - line.begin()) % space_count)
+                for i in xrange(0, spaces_to_insert): 
+                    self.view.insert(edit, region.begin(), " ")
 
 class VimShiftTabPressCommand(sublime_plugin.TextCommand):
     """

--- a/Vimdentation.py
+++ b/Vimdentation.py
@@ -56,10 +56,10 @@ class VimShiftTabPressCommand(sublime_plugin.TextCommand):
         sel = self.view.sel()
         for region in sel:
             selectedLines = self.view.lines(region)
-            for l in selectedLines:
+            for l in reversed(selectedLines):
                 # Extract the string from the line region
                 s = self.view.substr(l)
 
                 # Only do this if there are enough spaces to start
                 if s.find(spaces,0) == 0:
-                    self.view.replace(edit, l, s[space_count:])
+                    self.view.erase(edit, sublime.Region(l.begin(), l.begin() + space_count))


### PR DESCRIPTION
Adjusted VimShiftTabPress such that the caret stays in place and it works smoother as it approaches the left margin.

Reversing the line order allows the us to delete from the end first such that it does not mess up the previous lines.

Using erase allows the caret to stay in place.

Add code for handling tab stops
